### PR TITLE
Better ID attributes for FAQ entries (for v1.7.0)

### DIFF
--- a/includes/classes/arconix-faq-display.php
+++ b/includes/classes/arconix-faq-display.php
@@ -87,7 +87,7 @@ class Arconix_FAQ_Display {
                     'orderby'           => $args['orderby'],
                     'posts_per_page'    => $args['posts_per_page'],
                 );
-                
+
                 // Query our FAQ Posts
                 $q = new Arconix_FAQ_Query( $query_args, $term->slug );
 
@@ -173,7 +173,7 @@ class Arconix_FAQ_Display {
         $html = '';
 
         // Set up our anchor link
-        $link = 'faq-' . sanitize_html_class( get_the_title() );
+        $link = 'faq-' . sanitize_html_class( sanitize_title( get_the_title() ) );
 
         $html .= '<div id="faq-' . get_the_id() . '" class="arconix-faq-accordion-title">';
         $html .= get_the_title() . '</div>';
@@ -207,7 +207,7 @@ class Arconix_FAQ_Display {
         $lo == true ? $lo = ' faq-open' : $lo = ' faq-closed';
 
         // Set up our anchor link
-        $link = 'faq-' . sanitize_html_class( get_the_title() );
+        $link = 'faq-' . sanitize_html_class( sanitize_title( get_the_title() ) );
 
         $html .= '<div id="faq-' . get_the_id() . '" class="arconix-faq-wrap">';
         $html .= '<div id="' . $link . '" class="arconix-faq-title' . $lo . '">' . get_the_title() . '</div>';


### PR DESCRIPTION
`sanitize_title` strips HTML and converts whitespace to dashes. Currently, `My FAQ Entry` will yield the ID `faq-MyFAQEntry`. With these changes, the ID will be `faq-my-faq-entry`. 