### PR TITLE
Version 1.7.0

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://arconixpc.com/plugins/arconix-faq
  * Description: Plugin to handle the display of FAQs
  *
- * Version: 1.6.1
+ * Version: 1.7.0
  *
  * Author: John Gardner
  * Author URI: http://arconixpc.com/
@@ -41,7 +41,7 @@ class Arconix_FAQ {
      * @since   1.6.0
      */
     public function __construct() {
-        $this->version = '1.6.1';
+        $this->version = '1.7.0';
         $this->inc = trailingslashit( plugin_dir_path( __FILE__ ) . '/includes' );
         $this->load_dependencies();
         $this->load_admin();


### PR DESCRIPTION
= 1.7.0 =
* You can now exclude certain groups from the FAQs using the exclude_group attribute. The value of this attribute should be the slug of the group.

* Javascript and CSS files from the plugin will only be included when the shortcode is used on any page.

* You can now hide the titles of the groups using the hide_title attribute for the [faq] shortcode. The value should be true if you want to hide the titles else false.